### PR TITLE
Always show bookmark bar & windows minimize button fix

### DIFF
--- a/chrome/userChrome - WindowsTempFix.css
+++ b/chrome/userChrome - WindowsTempFix.css
@@ -14,9 +14,14 @@ Hopefully this theme is robust. I am happy with it at least
   margin-right: 160px;
 }
 
-#titlebar-buttonbox, #titlebar-buttonbox:-moz-window-inactive {
+/* #titlebar-buttonbox, #titlebar-buttonbox:-moz-window-inactive {
     display: block !important;
     opacity: 1 !important;
+} */
+
+#nav-bar {
+  max-width: 80% !important;
+  padding-right: 160px !important;
 }
 
 #TabsToolbar-customization-target > #alltabs-button {
@@ -46,7 +51,7 @@ Hopefully this theme is robust. I am happy with it at least
     margin-top: -40px;
   }
   #main-window[titlepreface*="🦊 "][tabsintitlebar="true"] #nav-bar {
-    margin-right: 160px;
+    margin-right: 90px;
   }
   #main-window[titlepreface*="🦊 "] #titlebar-spacer {
     background-color: var(--chrome-secondary-background-color);
@@ -135,41 +140,50 @@ Hopefully this theme is robust. I am happy with it at least
   /* Source file https://github.com/MrOtherGuy/firefox-csshacks/tree/master/chrome/autohide_bookmarks_toolbar.css made available under Mozilla Public License v. 2.0
   See the above repository for updates as well as full license text. */
    
-  #PersonalToolbar{
-    --uc-bm-height: 20px; /* Might need to adjust if the toolbar has other buttons */
-    --uc-bm-padding: 7px; /* Vertical padding to be applied to bookmarks */
-    --uc-autohide-toolbar-delay: 600ms; /* The toolbar is hidden after 0.6s */
+  /* #PersonalToolbar{ */
+    /* --uc-bm-height: 20px; Might need to adjust if the toolbar has other buttons */
+    /* --uc-bm-padding: 7px; Vertical padding to be applied to bookmarks */
+    /* --uc-autohide-toolbar-delay: 600ms; The toolbar is hidden after 0.6s */
    
     /* 0deg = "show" ; 90deg = "hide" ;  Set the following to control when bookmarks are shown */
-    --uc-autohide-toolbar-focus-rotation: 0deg; /* urlbar is focused */
-    --uc-autohide-toolbar-hover-rotation: 0deg; /* cursor is over the toolbar area */
-  }
+    /* --uc-autohide-toolbar-focus-rotation: 0deg; urlbar is focused */
+    /* --uc-autohide-toolbar-hover-rotation: 0deg; cursor is over the toolbar area */
+  /* } */
    
   :root[uidensity="compact"] #PersonalToolbar{ --uc-bm-padding: 1px; }
   :root[uidensity="touch"] #PersonalToolbar{ --uc-bm-padding: 7px }
    
-  #PersonalToolbar:not([customizing]){
+  /* #PersonalToolbar:not([customizing]){
     position: relative;
     margin-bottom: calc(0px - var(--uc-bm-height) - 2 * var(--uc-bm-padding));
     transform: rotateX(90deg);
     transform-origin: top;
     transition: transform 135ms linear var(--uc-autohide-toolbar-delay) !important;
     z-index: 1;
-    /* The following properties should allow the themes with trasparent toolbars to work */
+    The following properties should allow the themes with trasparent toolbars to work
     background-color: transparent !important;
     background-repeat: no-repeat,no-repeat,var(--lwt-background-tiling);
     --uc-bg-y: calc(-2 * (var(--tab-block-margin) + var(--toolbarbutton-inner-padding) + var(--toolbarbutton-outer-padding)) - var(--tab-min-height) - 16px - var(--bookmark-block-padding));
     background-position: top left,top left,var(--lwt-background-alignment,top left);
     background-position-y:top,top,var(--uc-bg-y),var(--uc-bg-y),var(--uc-bg-y);
     background-image: var(--toolbar-bgimage), linear-gradient(var(--toolbar-bgcolor),var(--toolbar-bgcolor)),var(--lwt-header-image,var(--lwt-additional-images)) !important;
-  }
+  } */
    
   #PlacesToolbarItems > .bookmark-item,
   #OtherBookmarks,
   #PersonalToolbar > #import-button{
     padding-block: var(--uc-bm-padding) !important;
   }
+
+  #PlacesToolbarItems {
+    display: flex !important;
+    justify-content: center !important;
+  }
    
+  #PersonalToolbar > * {
+    width: fit-content;
+  }
+
   #nav-bar:focus-within + #PersonalToolbar{
     transition-delay: 100ms !important;
     transform: rotateX(var(--uc-autohide-toolbar-focus-rotation,0));


### PR DESCRIPTION
### Summary: 

1. Always show bookmark bar (Commenting the sections)
2. Windows minimize button was removed after Firefox update, we are seeing a conflict between the navbar and the titlebar. Setting navbar to 80% width fixes that. 